### PR TITLE
Remove View Recipe from Navbar

### DIFF
--- a/front-end/src/Components/Navbar.jsx
+++ b/front-end/src/Components/Navbar.jsx
@@ -11,7 +11,6 @@ const Navbar = () => {
   { path: "/contacts", label: "Contact" },
   { path: `/user/${userID}`, label: "User" },
   { path: "/upload-recipe", label: "Upload Recipe" },
-  { path: "/view-recipe", label: "View Recipe" },
 ];
 
 


### PR DESCRIPTION
Removing the "View Recipe" link from Navbar as it no longer belongs there and furthermore it was leading to an error page because the view-recipe page no longer exists (meaningfully) on its own